### PR TITLE
Add Redis-backed cache implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,24 @@ func main() {
   client := memcached.New(&Config{Hosts: []string{"127.0.0.1:11211"}, NameSpace: "qor_demo_v1"})
 
   // Save value `Hello World` with key `hello_world` into cache store
-	err := client.Set("hello_world", "Hello World")
+  err := client.Set("hello_world", "Hello World")
 
   // Get saved value with key `hello_world`
-	result, err := client.Get("hello_world")
+  result, err := client.Get("hello_world")
 
   // Save marshal value of user into cache store
-	err := client.Set("user", user)
+  err := client.Set("user", user)
 
   // Unmarshal saved value into user2
-	err := client.Unmarshal("user", &user2)
+  err := client.Unmarshal("user", &user2)
 
   // Fetch saved value with key `hello_world`, if haven't find, will save returned result of `func` into cached store with passed key
-	result, err := client.Fetch("hello_world", func() interface{} {
+  result, err := client.Fetch("hello_world", func() interface{} {
     return "..."
   })
 
   // Delete saved value
-	err := client.Delete(key string)
+  err := client.Delete(key string)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ func main() {
   // Get saved value with key `hello_world`
   result, err := client.Get("hello_world")
 
-  // Save marshal value of user into cache store
+  // Save marshalled value of user into cache store
   err := client.Set("user", user)
 
   // Unmarshal saved value into user2
   err := client.Unmarshal("user", &user2)
 
-  // Fetch saved value with key `hello_world`, if haven't find, will save returned result of `func` into cached store with passed key
+  // Fetch saved value with key `hello_world`; if the key does not exist, the
+  // returned result of `func` will be saved into cache store under passed key
   result, err := client.Fetch("hello_world", func() interface{} {
     return "..."
   })
@@ -39,7 +40,7 @@ import "github.com/qor/cache/memory"
 
 func main() {
   client := memory.New()
-  // Same API with memcached cache store
+  // Same API as memcached cache store
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ func main() {
 }
 ```
 
+## Redis Cache Store Usage
+
+```go
+import "github.com/qor/cache/redis"
+
+func main() {
+  client = New(&redis.Options{Addr: "127.0.0.1:6379",
+    Password: "",   // no password set
+    DB:       0,    // use default DB
+    PoolSize: 100,
+  })
+  // Same API as memcached cache store
+}
+```
+
 ## License
 
 Released under the [MIT License](http://opensource.org/licenses/MIT).

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -1,0 +1,65 @@
+package redis
+
+import (
+	"encoding/json"
+
+	redis "gopkg.in/redis.v3"
+)
+
+// Redis provides a cache backed by a Redis server.
+type Redis struct {
+	Config *redis.Options
+	Client *redis.Client
+}
+
+// New returns an initialized Redis cache object.
+func New(config *redis.Options) *Redis {
+	client := redis.NewClient(config)
+	return &Redis{Config: config, Client: client}
+}
+
+// Get returns the value saved under a given key.
+func (r *Redis) Get(key string) (string, error) {
+	return r.Client.Get(key).Result()
+}
+
+// Unmarshal retrieves a value from the Redis server and unmarshals
+// it into the passed object.
+func (r *Redis) Unmarshal(key string, object interface{}) error {
+	value, err := r.Get(key)
+	if err == nil {
+		err = json.Unmarshal([]byte(value), object)
+	}
+	return err
+}
+
+// Set saves an arbitrary value under a specific key.
+func (r *Redis) Set(key string, value interface{}) error {
+	return r.Client.Set(key, convertToBytes(value), 0).Err()
+}
+
+func convertToBytes(value interface{}) []byte {
+	switch result := value.(type) {
+	case string:
+		return []byte(result)
+	case []byte:
+		return result
+	default:
+		bytes, _ := json.Marshal(value)
+		return bytes
+	}
+}
+
+// Fetch returns the value for the key if it exists or sets and returns the value via the passed function.
+func (r *Redis) Fetch(key string, fc func() interface{}) (string, error) {
+	if str, err := r.Get(key); err == nil {
+		return str, nil
+	}
+	results := convertToBytes(fc())
+	return string(results), r.Set(key, results)
+}
+
+// Delete removes a specific key and its value from the Redis server.
+func (r *Redis) Delete(key string) error {
+	return r.Client.Del(key).Err()
+}

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -1,0 +1,87 @@
+package redis
+
+import (
+	"reflect"
+	"testing"
+
+	"gopkg.in/redis.v3"
+
+	"github.com/qor/cache"
+)
+
+var client cache.CacheStoreInterface
+
+func init() {
+	client = New(&redis.Options{Addr: "127.0.0.1:6379",
+		Password: "", // no password set
+		DB:       0,  // use default DB
+		PoolSize: 100,
+	})
+}
+
+func TestPlainText(t *testing.T) {
+	if err := client.Set("hello_world", "Hello World"); err != nil {
+		t.Errorf("No error should happen when saving plain text into client")
+	}
+
+	if value, err := client.Get("hello_world"); err != nil || value != "Hello World" {
+		t.Errorf("found value: %v", value)
+	}
+
+	if err := client.Set("hello_world", "Hello World2"); err != nil {
+		t.Errorf("No error should happen when updating saved value")
+	}
+
+	if value, err := client.Get("hello_world"); err != nil || value != "Hello World2" {
+		t.Errorf("value should been updated: %v", value)
+	}
+
+	if err := client.Delete("hello_world"); err != nil {
+		t.Errorf("failed to delete value: %v", err)
+	}
+
+	if _, err := client.Get("hello_world"); err == nil {
+		t.Errorf("the key should been deleted")
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	type result struct {
+		Name  string
+		Value string
+	}
+
+	r1 := result{Name: "result_name_1", Value: "result_value_1"}
+	if err := client.Set("unmarshal", r1); err != nil {
+		t.Errorf("No error should happen when saving struct into client: %v", err)
+	}
+
+	var r2 result
+	if err := client.Unmarshal("unmarshal", &r2); err != nil || !reflect.DeepEqual(r1, r2) {
+		t.Errorf("found value: %#v", r2)
+	}
+
+	if err := client.Delete("unmarshal"); err != nil {
+		t.Errorf("failed to delete value: %v", err)
+	}
+
+	if err := client.Unmarshal("unmarshal", &r2); err == nil {
+		t.Errorf("the key should been deleted")
+	}
+}
+
+func TestFetch(t *testing.T) {
+	var result int
+	var fc = func() interface{} {
+		result++
+		return result
+	}
+
+	if value, err := client.Fetch("fetch", fc); err != nil || value != "1" {
+		t.Errorf("Should get result from func if key not found")
+	}
+
+	if value, err := client.Fetch("fetch", fc); err != nil || value != "1" {
+		t.Errorf("Should lookup result from cache store if key is existing")
+	}
+}


### PR DESCRIPTION
This is based on the `github.com/go-redis/redis` library and pins the version to v3 on gopkg.in. The tests are an exact copy of the Memcache unit tests and all are passing.
